### PR TITLE
renamed domain for HACS compatibility

### DIFF
--- a/custom_components/homeassistant-edupage/const.py
+++ b/custom_components/homeassistant-edupage/const.py
@@ -1,4 +1,4 @@
 """Constants for the EduPage Schooling System component."""
 
 # Component domain, used to store component data in hass data.
-DOMAIN = "homeassistant-edupage"
+DOMAIN = "homeassistantedupage"

--- a/custom_components/homeassistant-edupage/manifest.json
+++ b/custom_components/homeassistant-edupage/manifest.json
@@ -1,5 +1,5 @@
 {
-    "domain": "homeassistant-edupage",
+    "domain": "homeassistantedupage",
     "name": "homeassistant-edupage",
     "codeowners": ["@rine77"],
     "config_flow": true,


### PR DESCRIPTION
* homeassistant-edupage renamed to homeassistantedupage, but only domain not repo